### PR TITLE
Add missing numerical sort.

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -22,7 +22,7 @@ fi
 
 sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+    LC_ALL=C sort -t. -k 1,1n -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
 list_github_tags() {


### PR DESCRIPTION
This PR adds missing numerical sort option to the plugin. This will fix latest versions. 

Example before changes:
```
...
9.3.7
9.3.9
9.3.10
9.3.11
9.3.12
```

Example after changes
```
...
9.3.10
9.3.11
9.3.12
10.0.0
10.0.1
10.0.2
```