### PR TITLE
Allow architecture overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ asdf global teleport latest
 
 # Now teleport commands are available
 tsh version
+
+# Override the architecture of installed binary
+# For example, to install amd64 binary on and M1 Mac
+TELEPORT_ARCH_OVERRIDE=amd64 asdf install telerpot latest
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -60,6 +60,10 @@ download_release() {
   *) fail "Unsupported architecture" ;;
   esac
 
+  if [ -n "${TELEPORT_ARCH_OVERRIDE-}" ]; then
+    architecture="${TELEPORT_ARCH_OVERRIDE-}"
+  fi
+
   # TODO: Adapt the release URL convention for teleport
   url="$DOWNLOAD_URL/teleport-v${version}-${platform}-${architecture}-bin.tar.gz"
 


### PR DESCRIPTION
When attempting to install an older version of teleport (6.x, for example) on an M1 mac, I ran into an issue with lack of arm64 binaries for such an old release. Allow to override the architecture so I could install amd64 binary and run it through Rosetta. In fact, `teleport` does not publish any `darvin-arm64` binaries yet.